### PR TITLE
fix: parties 객체가 parties로 래핑되던 문제 수정

### DIFF
--- a/back/src/domain/session/session.controller.ts
+++ b/back/src/domain/session/session.controller.ts
@@ -23,7 +23,7 @@ export class SessionController {
         const parties = await this.sessionService.getSessionParties(sessionId);
         const events$ = new BehaviorSubject({
             type: 'CONNECT',
-            data: { parties },
+            data: parties,
         });
 
         req.on('close', () => {


### PR DESCRIPTION
- 문제 상황: API 응답 데이터가 parties: {parties: {...}}와 같이 parties로 한 번더 래핑되는 문제가 발생
- 해결 방법: events 스트림에 데이터를 넣는 과정에서 object로 래핑되어있던 부분 수정
  - data: {parties} -> data: parties